### PR TITLE
feat: support use extra btf as kernel spec when it is not enabled

### DIFF
--- a/pkg/btfs/btfs.go
+++ b/pkg/btfs/btfs.go
@@ -1,0 +1,68 @@
+package btfs
+
+import (
+	"bytes"
+	"embed"
+	"sync"
+	"syscall"
+
+	"github.com/cilium/ebpf/btf"
+)
+
+func init() {
+	setKernelSpec()
+}
+
+var BtfSpec *btf.Spec
+
+var (
+	once sync.Once
+	// TODO: add more kernel release to btf file mapping
+	releaseToBtf = map[string]string{
+		"5.10.134-16.1.al8.x86_64":    "5.4.28-200.el7.x86_64.btf",
+		"5.4.278-1.el7.elrepo.x86_64": "5.4.28-200.el7.x86_64.btf",
+		"5.5.5-1.el7.elrepo.x86_64":   "5.4.28-200.el7.x86_64.btf",
+	}
+)
+
+//go:embed archives/*
+var btfFiles embed.FS
+
+func int8ToStr(arr []int8) string {
+	b := make([]byte, 0, len(arr))
+	for _, v := range arr {
+		if v == 0x00 {
+			break
+		}
+		b = append(b, byte(v))
+	}
+	return string(b)
+}
+
+func setKernelSpec() {
+	once.Do(func() {
+		btfSpec, err := btf.LoadKernelSpec()
+		if err != nil {
+			var uname syscall.Utsname
+			if err := syscall.Uname(&uname); err != nil {
+				panic(err)
+			}
+			release := int8ToStr(uname.Release[:])
+			releaseTarget, ok := releaseToBtf[release]
+			if !ok {
+				panic("no btf file found for kernel release: " + release)
+			}
+			btfFileReader, err := btfFiles.ReadFile("archives/" + releaseTarget)
+			if err != nil {
+				panic(err)
+			}
+			btfSpec, err = btf.LoadSpecFromReader(bytes.NewReader(btfFileReader))
+			if err != nil {
+				panic(err)
+			}
+			BtfSpec = btfSpec
+			return
+		}
+		BtfSpec = btfSpec
+	})
+}

--- a/pkg/plugins/kprobe/kprobesysctl/ebpf_kprobe_sysctl.go
+++ b/pkg/plugins/kprobe/kprobesysctl/ebpf_kprobe_sysctl.go
@@ -10,9 +10,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/erda-project/ebpf-agent/metric"
+	"github.com/erda-project/ebpf-agent/pkg/btfs"
 	"github.com/erda-project/ebpf-agent/pkg/envconf"
 	"github.com/erda-project/ebpf-agent/pkg/exporter/collector"
 	"github.com/patrickmn/go-cache"
@@ -44,7 +46,11 @@ func New(clientSet *kubernetes.Clientset) *KprobeSysctlController {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		log.Fatal(err)
 	}
-	if err := loadBpfObjects(&objs, nil); err != nil {
+	if err := loadBpfObjects(&objs, &ebpf.CollectionOptions{
+		Programs: ebpf.ProgramOptions{
+			KernelTypes: btfs.BtfSpec,
+		},
+	}); err != nil {
 		log.Fatalf("loading objects: %v", err)
 	}
 	reportConfig := &collector.CollectorConfig{}

--- a/pkg/plugins/memory/oomprocesser/ebpf_oom_kill_process.go
+++ b/pkg/plugins/memory/oomprocesser/ebpf_oom_kill_process.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"github.com/erda-project/ebpf-agent/pkg/btfs"
 	"k8s.io/klog"
 )
 
@@ -28,7 +29,11 @@ func WatchOOM(ch chan<- *OOMEvent) {
 		log.Fatal(err)
 	}
 
-	coll, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{})
+	coll, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{
+		Programs: ebpf.ProgramOptions{
+			KernelTypes: btfs.BtfSpec,
+		},
+	})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/plugins/netfilter/ebpf/bpf_netfilter.go
+++ b/pkg/plugins/netfilter/ebpf/bpf_netfilter.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/cilium/ebpf"
+	"github.com/erda-project/ebpf-agent/pkg/btfs"
 )
 
 func RunEbpf() *NetfilterObjects {
@@ -16,7 +17,8 @@ func RunEbpf() *NetfilterObjects {
 	var bpfObj NetfilterObjects
 	if err := spec.LoadAndAssign(&bpfObj, &ebpf.CollectionOptions{
 		Programs: ebpf.ProgramOptions{
-			LogSize: ebpf.DefaultVerifierLogSize * 10,
+			LogSize:     ebpf.DefaultVerifierLogSize * 10,
+			KernelTypes: btfs.BtfSpec,
 		},
 	}); err != nil {
 		panic(err)

--- a/pkg/plugins/protocols/http/ebpf/provider.go
+++ b/pkg/plugins/protocols/http/ebpf/provider.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/erda-project/ebpf-agent/pkg/btfs"
 	"k8s.io/klog/v2"
 
 	"github.com/erda-project/ebpf-agent/pkg/utils"
@@ -61,7 +62,11 @@ func (e *provider) Load() error {
 	if err != nil {
 		return err
 	}
-	e.collection, err = ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{})
+	e.collection, err = ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{
+		Programs: ebpf.ProgramOptions{
+			KernelTypes: btfs.BtfSpec,
+		},
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/protocols/kafka/ebpf.go
+++ b/pkg/plugins/protocols/kafka/ebpf.go
@@ -5,13 +5,15 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/cilium/ebpf"
 	"io/ioutil"
-	"k8s.io/klog"
 	"log"
 	"syscall"
 	"time"
 	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/erda-project/ebpf-agent/pkg/btfs"
+	"k8s.io/klog"
 )
 
 const (
@@ -43,7 +45,11 @@ func NewEbpf(ifindex int, ip string, ch chan Event) *Ebpf {
 func (e *Ebpf) Load(spec *ebpf.CollectionSpec) error {
 	klog.Infof("ip: %s, index: %d start kafka", e.IPaddress, e.IfIndex)
 	var err error
-	e.collection, err = ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{})
+	e.collection, err = ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{
+		Programs: ebpf.ProgramOptions{
+			KernelTypes: btfs.BtfSpec,
+		},
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/protocols/rpc/ebpf/ebpf.go
+++ b/pkg/plugins/protocols/rpc/ebpf/ebpf.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/klog"
 	"log"
 	"sync"
 	"syscall"
@@ -12,6 +11,8 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"github.com/erda-project/ebpf-agent/pkg/btfs"
+	"k8s.io/klog"
 )
 
 const (
@@ -70,7 +71,11 @@ func NewEbpf(ifindex int, ip string, ch chan Metric) *Ebpf {
 func (e *Ebpf) Load(spec *ebpf.CollectionSpec) error {
 	klog.Infof("ip: %s, index: %d start rpc", e.IPaddress, e.IfIndex)
 	var err error
-	e.collection, err = ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{})
+	e.collection, err = ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{
+		Programs: ebpf.ProgramOptions{
+			KernelTypes: btfs.BtfSpec,
+		},
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
support use extra btf as kernel spec when it is not enabled

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=621468&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: support use extra btf as kernel spec when it is not enabled （支持低版本内核没有开启btf的机器运行ebpf）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    support use extra btf as kernel spec when it is not enabled           |
| 🇨🇳 中文    |   支持低版本内核没有开启btf的机器运行ebpf           |

